### PR TITLE
Update webhook-handler.js exports.default

### DIFF
--- a/webhook-handler.js
+++ b/webhook-handler.js
@@ -29,4 +29,4 @@ function myEntrypoint(params) {
   logData(params);
 }
 
-exports.main = myEntrypoint;
+exports.default = myEntrypoint;


### PR DESCRIPTION
I think we should use `exports.default` instead of `exports.main`.  In case there are issues with the current action code, you can merge this PR, run `npm install` , update the repo, and then test.